### PR TITLE
Update score-compose/dapr.tpl - add `scheduler`

### DIFF
--- a/score-compose/dapr.tpl
+++ b/score-compose/dapr.tpl
@@ -36,7 +36,7 @@
   value: ghcr.io/dapr/daprd:latest
 - op: set
   path: services.{{ $name }}-sidecar.command
-  value: ["./daprd", "--app-id={{ dig "annotations" "dapr.io/app-id" "" $cfg }}", "--app-port={{ dig "annotations" "dapr.io/app-port" "" $cfg }}", "--enable-api-logging={{ dig "annotations" "dapr.io/enable-api-logging" false $cfg }}", "--placement-host-address=placement:50006", "--resources-path=/components"]
+  value: ["./daprd", "--app-id={{ dig "annotations" "dapr.io/app-id" "" $cfg }}", "--app-port={{ dig "annotations" "dapr.io/app-port" "" $cfg }}", "--enable-api-logging={{ dig "annotations" "dapr.io/enable-api-logging" false $cfg }}", "--placement-host-address=placement:50006", "--scheduler-host-address=scheduler:50007", "--resources-path=/components"]
 - op: set
   path: services.{{ $name }}-sidecar.network_mode
   value: service:{{ $name }}

--- a/score-compose/dapr.tpl
+++ b/score-compose/dapr.tpl
@@ -1,6 +1,6 @@
 - op: set
   path: services.placement.image
-  value: daprio/dapr
+  value: ghcr.io/dapr/placement:latest
 - op: set
   path: services.placement.command
   value: ["./placement", "--port", "50006"]
@@ -11,7 +11,7 @@
     published: "50006"
 - op: set
   path: services.scheduler.image
-  value: daprio/dapr
+  value: ghcr.io/dapr/scheduler:latest
 - op: set
   path: services.scheduler.command
   value: ["./scheduler", "--port", "50007"]
@@ -23,24 +23,15 @@
 - op: set
   path: services.scheduler.volumes
   value:
-  - type: volume
-    source: scheduler-data
+  - type: tmpfs
     target: /data
-  #- type: tmpfs
-  #  target: /data
-  #  tmpfs:
-  #    size: 128
-- op: set
-  path: volumes.scheduler-data.name
-  value: scheduler-data
-- op: set
-  path: volumes.scheduler-data.driver
-  value: local
+    tmpfs:
+      size: 128
 {{ range $name, $cfg := .Compose.services }}
 {{ if dig "annotations" "dapr.io/enabled" false $cfg }}
 - op: set
   path: services.{{ $name }}-sidecar.image
-  value: daprio/daprd:latest
+  value: ghcr.io/dapr/daprd:latest
 - op: set
   path: services.{{ $name }}-sidecar.command
   value: ["./daprd", "--app-id={{ dig "annotations" "dapr.io/app-id" "" $cfg }}", "--app-port={{ dig "annotations" "dapr.io/app-port" "" $cfg }}", "--enable-api-logging={{ dig "annotations" "dapr.io/enable-api-logging" false $cfg }}", "--placement-host-address=placement:50006", "--resources-path=/components"]

--- a/score-compose/dapr.tpl
+++ b/score-compose/dapr.tpl
@@ -3,12 +3,39 @@
   value: daprio/dapr
 - op: set
   path: services.placement.command
-  value: ["./placement", "-port", "50006"]
+  value: ["./placement", "--port", "50006"]
 - op: set
   path: services.placement.ports
   value:
   - target: 50006
     published: "50006"
+- op: set
+  path: services.scheduler.image
+  value: daprio/dapr
+- op: set
+  path: services.scheduler.command
+  value: ["./scheduler", "--port", "50007"]
+- op: set
+  path: services.scheduler.ports
+  value:
+  - target: 50007
+    published: "50007"
+- op: set
+  path: services.scheduler.volumes
+  value:
+  - type: volume
+    source: scheduler-data
+    target: /data
+  #- type: tmpfs
+  #  target: /data
+  #  tmpfs:
+  #    size: 128
+- op: set
+  path: volumes.scheduler-data.name
+  value: scheduler-data
+- op: set
+  path: volumes.scheduler-data.driver
+  value: local
 {{ range $name, $cfg := .Compose.services }}
 {{ if dig "annotations" "dapr.io/enabled" false $cfg }}
 - op: set

--- a/score-compose/dapr.tpl
+++ b/score-compose/dapr.tpl
@@ -14,7 +14,7 @@
   value: ghcr.io/dapr/scheduler:latest
 - op: set
   path: services.scheduler.command
-  value: ["./scheduler", "--port", "50007"]
+  value: ["./scheduler", "--port", "50007", "--etcd-data-dir", "/data"]
 - op: set
   path: services.scheduler.ports
   value:
@@ -23,10 +23,12 @@
 - op: set
   path: services.scheduler.volumes
   value:
-  - type: tmpfs
+  - type: bind
+    source: ./dapr-etcd-data/
     target: /data
-    tmpfs:
-      size: 128
+- op: set
+  path: services.scheduler.user
+  value: root
 {{ range $name, $cfg := .Compose.services }}
 {{ if dig "annotations" "dapr.io/enabled" false $cfg }}
 - op: set


### PR DESCRIPTION
Adding `scheduler` to support Dapr Workflow natively.

Also, reducing container images size uncompressed on disk:
```
ghcr.io/dapr/placement  latest          a68b826f3920  2 weeks ago  44.1 MB
ghcr.io/dapr/scheduler  latest          7fa8825f4275  2 weeks ago  56.6 MB
ghcr.io/dapr/dapr       latest          9f2f74136c57  2 weeks ago  437 MB
```
Getting specific and smaller `placement` or `scheduler` ones instead of  bigger `dapr` one. Saving 437-44.1-56.6=`336.3 MB`.