### PR TITLE
`--namespace`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-*/compose.yaml
-*/manifests.yaml
-*/score.yaml
+**/compose.yaml
+**/manifests.yaml
+**/score.yaml
+.score-k8s/
+.score-compose/

--- a/score-k8s/service-account-admin.tpl
+++ b/score-k8s/service-account-admin.tpl
@@ -1,3 +1,4 @@
+{{ $namespace := .Namespace }}
 {{ range $i, $m := .Manifests }}
 {{ if eq $m.kind "Deployment" }}
 - op: set
@@ -7,6 +8,9 @@
     kind: ServiceAccount
     metadata:
       name: {{ $m.metadata.name }}
+      {{ if ne $namespace "" }}
+      namespace: {{ $namespace }}
+      {{ end }}
 - op: set
   path: -1
   value:
@@ -21,6 +25,9 @@
     subjects:
     - kind: ServiceAccount
       name: {{ $m.metadata.name }}
+      {{ if ne $namespace "" }}
+      namespace: {{ $namespace }}
+      {{ end }}
 - op: set
   path: {{ $i }}.spec.template.spec.serviceAccountName
   value: {{ $m.metadata.name }}

--- a/score-k8s/service-account.tpl
+++ b/score-k8s/service-account.tpl
@@ -1,3 +1,4 @@
+{{ $namespace := .Namespace }}
 {{ range $i, $m := .Manifests }}
 {{ if eq $m.kind "Deployment" }}
 - op: set
@@ -7,6 +8,9 @@
     kind: ServiceAccount
     metadata:
       name: {{ $m.metadata.name }}
+      {{ if ne $namespace "" }}
+      namespace: {{ $namespace }}
+      {{ end }}
 - op: set
   path: {{ $i }}.spec.template.spec.serviceAccountName
   value: {{ $m.metadata.name }}


### PR DESCRIPTION
Take into account `--namespace` based on https://github.com/score-spec/score-k8s/pull/183 since `score-k8s` version `0.5.2`.

Note: if these new versions of these patch templates are used with `score-k8s` version < `0.5.2`, this error message below will happen with `score-k8s generate`:
```none
Error: failed to patch template 1: failed to execute template: template: :1:17: executing "" at <.Namespace>: can't evaluate field Namespace in type patching.patchTemplateInput
```