### PR TITLE
namespace-pss-restricted

### DIFF
--- a/score-k8s/namespace-pss-restricted.tpl
+++ b/score-k8s/namespace-pss-restricted.tpl
@@ -1,0 +1,7 @@
+{{ range $i, $m := .Manifests }}
+{{ if eq $m.kind "Namespace" }}
+- op: set
+  path: {{ $i }}.metadata.labels.pod-security\.kubernetes\.io/enforce
+  value: restricted
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Add the PSS `restricted` `label` on the generated `Namespace`:
```bash
score-k8s init --patch-templates ./score-k8s/namespace-restricted.tpl
score-k8s generate score.yaml --namespace test --generate-namespace
cat manifests.yaml
```

```yaml
---
apiVersion: v1
kind: Namespace
metadata:
    labels:
        app.kubernetes.io/managed-by: score-k8s
        pod-security.kubernetes.io/enforce: restricted
    name: test
...
```

